### PR TITLE
fix: error caused by slash in name and OPENSSL_CONF

### DIFF
--- a/scripts/download-all.sh
+++ b/scripts/download-all.sh
@@ -5,10 +5,10 @@ set -o pipefail
 
 export OPENSSL_CONF="openssl.cnf"
 args=(tld)
-for year in {2020..2023}; do
+for year in {2020..2024}; do
   for term in {1..3}; do
     semester="${year}-$((year + 1))-${term}"
     args+=(--semester="${semester}")
   done
 done
-"${args[@]}"
+OPENSSL_CONF="openssl.cnf" "${args[@]}"

--- a/thu_learn_downloader/download/filename.py
+++ b/thu_learn_downloader/download/filename.py
@@ -49,7 +49,9 @@ def attachment(
 ) -> Path:
     filename: Path = Path(attachment.name)
     filename = filename.with_stem(
-        f"{homework.number:02d}-{homework.title}-{attachment.type_}".replace("/", "-slash-")
+        f"{homework.number:02d}-{homework.title}-{attachment.type_}".replace(
+            "/", "-slash-"
+        )
     )
     return (
         prefix

--- a/thu_learn_downloader/download/filename.py
+++ b/thu_learn_downloader/download/filename.py
@@ -20,7 +20,7 @@ def document(
         / course.name
         / "docs"
         / document_class.title
-        / f"{index:02d}-{document.title}"
+        / f"{index:02d}-{document.title}".replace("/", "-slash-")
     )
     if document.file_type:
         filename = filename.with_suffix("." + document.file_type)
@@ -35,7 +35,7 @@ def homework(
         / semester.id
         / course.name
         / "work"
-        / f"{homework.number:02d}-{homework.title}"
+        / f"{homework.number:02d}-{homework.title}".replace("/", "-slash-")
         / "README.md"
     )
 
@@ -49,13 +49,13 @@ def attachment(
 ) -> Path:
     filename: Path = Path(attachment.name)
     filename = filename.with_stem(
-        f"{homework.number:02d}-{homework.title}-{attachment.type_}"
+        f"{homework.number:02d}-{homework.title}-{attachment.type_}".replace("/", "-slash-")
     )
     return (
         prefix
         / semester.id
         / course.name
         / "work"
-        / f"{homework.number:02d}-{homework.title}"
+        / f"{homework.number:02d}-{homework.title}".replace("/", "-slash-")
         / filename
     )


### PR DESCRIPTION
fix error caused by slash('/') in homework name; add OPENSSL_CONF env which is useful on MacOS; add courses of 2024-2025